### PR TITLE
Refactor: update settings use meta

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -6,18 +6,18 @@
 
 	// Define the new component for the conversion tracking tab
 	const ConversionTrackingTab = ({ settings, setSettings }) => {
-		const { conversionTrackingEnabled, conversionLabel, googleConversionTrackingId } = settings;
+		const { conversionBridgeTrackingEnabled = false, conversionBridgeTrackingLabel = '', conversionBridgeTrackingId } = {...window.conversionBridgeSettings, ...settings};
 
 		const handleToggleChange = () => {
-			setSettings({ ...settings, conversionTrackingEnabled: !conversionTrackingEnabled });
+			setSettings({ ...settings, conversionBridgeTrackingEnabled: !conversionBridgeTrackingEnabled });
 		};
 
-		const handleConversionLabelChange = (conversionLabel) => {
-			setSettings({ ...settings, conversionLabel });
+		const handleConversionBridgeTrackingLabelChange = (conversionBridgeTrackingLabel) => {
+			setSettings({ ...settings, conversionBridgeTrackingLabel });
 		};
 
-		const handleGoogleTrackingIdChange = (googleConversionTrackingId) => {
-			setSettings({ ...settings, googleConversionTrackingId });
+		const handleGoogleTrackingIdChange = (conversionBridgeTrackingId) => {
+			setSettings({ ...settings, conversionBridgeTrackingId });
 		};
 
 		return createElement(
@@ -28,11 +28,11 @@
 				{ className: 'no-extra-gap' },
 				createElement(ToggleControl, {
 					label: __('Enable conversion tracking', 'give'),
-					checked: conversionTrackingEnabled,
+					checked: conversionBridgeTrackingEnabled,
 					onChange: handleToggleChange,
 				})
 			),
-			conversionTrackingEnabled && createElement(
+			conversionBridgeTrackingEnabled && createElement(
 				Fragment,
 				null,
 				createElement(
@@ -40,8 +40,8 @@
 					null,
 					createElement(TextControl, {
 						label: __('Conversion Label', 'give'),
-						value: conversionLabel,
-						onChange: handleConversionLabelChange,
+						value: conversionBridgeTrackingLabel,
+						onChange: handleConversionBridgeTrackingLabelChange,
 					})
 				),
 				createElement(
@@ -49,7 +49,7 @@
 					null,
 					createElement(TextControl, {
 						label: __('Google Conversion Tracking ID', 'give'),
-						value: googleConversionTrackingId,
+						value: conversionBridgeTrackingId,
 						onChange: handleGoogleTrackingIdChange,
 					})
 				)

--- a/index.php
+++ b/index.php
@@ -20,9 +20,9 @@ function add_custom_route_script() {
     $formId = isset($_GET['donationFormID']) ?  abs($_GET['donationFormID']) : null;
 
     wp_localize_script('conversion-bridge-givewp', 'conversionBridgeSettings', [
-        'conversionBridgeTrackingEnabled' =>  give()->form_meta->get_meta($formId, 'conversionBridgeTrackingEnabled', true),
-        'conversionBridgeTrackingLabel' =>  give()->form_meta->get_meta($formId, 'conversionBridgeTrackingLabel', true),
-        'conversionBridgeTrackingId' =>  give()->form_meta->get_meta($formId, 'conversionBridgeTrackingId', true)
+        'conversionBridgeTrackingEnabled' =>  give()->form_meta->get_meta($formId, 'conversion_bridge_tracking_enabled', true),
+        'conversionBridgeTrackingLabel' =>  give()->form_meta->get_meta($formId, 'conversion_bridge_tracking_label', true),
+        'conversionBridgeTrackingId' =>  give()->form_meta->get_meta($formId, 'conversion_bridge_tracking_id', true)
     ]);
 }
 
@@ -33,17 +33,17 @@ add_action('givewp_form_builder_updated', function($form) {
 
         if (isset($settings['conversionBridgeTrackingEnabled'])){
             $conversionBridgeTrackingEnabled = give_clean($settings['conversionBridgeTrackingEnabled']);
-            give()->form_meta->update_meta($formId, 'conversionBridgeTrackingEnabled', $conversionBridgeTrackingEnabled);
+            give()->form_meta->update_meta($formId, 'conversion_bridge_tracking_enabled', $conversionBridgeTrackingEnabled);
         }
 
         if (isset($settings['conversionBridgeTrackingLabel'])){
             $conversionBridgeTrackingLabel = give_clean($settings['conversionBridgeTrackingLabel']);
-            give()->form_meta->update_meta($formId, 'conversionBridgeTrackingLabel', $conversionBridgeTrackingLabel);
+            give()->form_meta->update_meta($formId, 'conversion_bridge_tracking_label', $conversionBridgeTrackingLabel);
         }
 
         if (isset($settings['conversionBridgeTrackingId'])){
             $conversionBridgeTrackingId = give_clean($settings['conversionBridgeTrackingId']);
-            give()->form_meta->update_meta($formId, 'conversionBridgeTrackingId', $conversionBridgeTrackingId);
+            give()->form_meta->update_meta($formId, 'conversion_bridge_tracking_id', $conversionBridgeTrackingId);
         }
     }
 });

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@
  * Version:     0.1
  */
 
-add_action( 'admin_enqueue_scripts', 'add_custom_route_script' );
+add_action( 'givewp_form_builder_enqueue_scripts', 'add_custom_route_script' );
 function add_custom_route_script() {
 	wp_enqueue_script(
 		'conversion-bridge-givewp',
@@ -16,4 +16,34 @@ function add_custom_route_script() {
 		null,
 		true
 	);
+
+    $formId = isset($_GET['donationFormID']) ?  abs($_GET['donationFormID']) : null;
+
+    wp_localize_script('conversion-bridge-givewp', 'conversionBridgeSettings', [
+        'conversionBridgeTrackingEnabled' =>  give()->form_meta->get_meta($formId, 'conversionBridgeTrackingEnabled', true),
+        'conversionBridgeTrackingLabel' =>  give()->form_meta->get_meta($formId, 'conversionBridgeTrackingLabel', true),
+        'conversionBridgeTrackingId' =>  give()->form_meta->get_meta($formId, 'conversionBridgeTrackingId', true)
+    ]);
 }
+
+add_action('givewp_form_builder_updated', function($form) {
+    if (isset($_POST['settings'])){
+        $settings = json_decode(give_clean($_POST['settings']), true);
+        $formId = $form->id;
+
+        if (isset($settings['conversionBridgeTrackingEnabled'])){
+            $conversionBridgeTrackingEnabled = give_clean($settings['conversionBridgeTrackingEnabled']);
+            give()->form_meta->update_meta($formId, 'conversionBridgeTrackingEnabled', $conversionBridgeTrackingEnabled);
+        }
+
+        if (isset($settings['conversionBridgeTrackingLabel'])){
+            $conversionBridgeTrackingLabel = give_clean($settings['conversionBridgeTrackingLabel']);
+            give()->form_meta->update_meta($formId, 'conversionBridgeTrackingLabel', $conversionBridgeTrackingLabel);
+        }
+
+        if (isset($settings['conversionBridgeTrackingId'])){
+            $conversionBridgeTrackingId = give_clean($settings['conversionBridgeTrackingId']);
+            give()->form_meta->update_meta($formId, 'conversionBridgeTrackingId', $conversionBridgeTrackingId);
+        }
+    }
+});


### PR DESCRIPTION
### Description

GiveWP currently has the ability to add a custom form setting.  However, the ability to persist the setting is limited to known GiveWP add-on settings.  This workaround for 3rd parties is to use form meta to persist the settings.

GiveWP Form Meta Keys (`give_formmeta`):
- `conversion_bridge_tracking_enabled`
- `conversion_bridge_tracking_label`
- `conversion_bridge_tracking_id`